### PR TITLE
refactor: AdviceFactory와 AdviceMapper에서 Repository 의존성 제거

### DIFF
--- a/src/main/java/com/example/weesh/core/advice/application/AdviceRepository.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceRepository.java
@@ -1,12 +1,14 @@
 package com.example.weesh.core.advice.application;
 
 import com.example.weesh.core.advice.domain.Advice;
+import com.example.weesh.core.user.domain.User;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface AdviceRepository {
     Advice save(Advice advice);
+    Advice save(Advice advice, User user);
     Optional<Advice> findById(Long id);
     List<Advice> findAll();
     boolean existsByDateAndTime(String desiredDate, String desiredTime);

--- a/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
@@ -33,7 +33,7 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
         String token = tokenResolver.resolveToken(request); // 요청에서 토큰 추출
         Long userId = token != null ? getUserIdFromToken(token) : null;
         User user = userId != null ? userRepository.findById(userId) : null;
-        validateAdviceRequest(dto, userId);
+        validateAdviceRequest(dto, userId, user);
         validateDuplicateAdvice(dto);
         Advice advice = adviceFactory.createAdvice(dto, userId);
         Advice savedAdvice = adviceRepository.save(advice, user);
@@ -90,13 +90,11 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
         }
     }
 
-    private void validateAdviceRequest(AdviceCreateRequestDto dto, Long userId) {
+    private void validateAdviceRequest(AdviceCreateRequestDto dto, Long userId, User user) {
         if (userId != null) {
             if (dto.getStudentNumber() != null || dto.getFullName() != null) {
                 throw new IllegalStateException("토큰 값이 있으면 학번 및 이름 필드엔 값이 없어야 합니다.");
             }
-            // 로그인 시 사용자 정보 자동 설정 (예시)
-            User user = userRepository.findById(userId);
             if (user == null) {
                 throw new IllegalStateException("User not found");
             }

--- a/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
@@ -7,6 +7,7 @@ import com.example.weesh.core.auth.application.token.TokenResolver;
 import com.example.weesh.core.auth.application.token.TokenValidator;
 import com.example.weesh.core.user.application.UserRepository;
 import com.example.weesh.core.user.domain.User;
+import com.example.weesh.core.user.exception.DuplicateUserException;
 import com.example.weesh.web.advice.dto.AdviceCreateRequestDto;
 import com.example.weesh.web.advice.dto.AdviceResponseDto;
 import com.example.weesh.web.advice.dto.AdviceUpdateRequestDro;
@@ -33,6 +34,7 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
         String token = tokenResolver.resolveToken(request); // 요청에서 토큰 추출
         Long userId = token != null ? getUserIdFromToken(token) : null;
         validateAdviceRequest(dto, userId);
+        validateDuplicateAdvice(dto);
         Advice advice = adviceFactory.createAdvice(dto, userId);
         Advice savedAdvice = adviceRepository.save(advice);
         return new AdviceResponseDto(savedAdvice);
@@ -104,6 +106,12 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
             if (dto.getStudentNumber() == null || dto.getFullName() == null) {
                 throw new IllegalStateException("비로그인 시 학번과 이름은 필수입니다.");
             }
+        }
+    }
+
+    private void validateDuplicateAdvice(AdviceCreateRequestDto dto) {
+        if (adviceRepository.existsByDateAndTime(dto.getDesiredDate(), dto.getDesiredTime())) {
+            throw new DuplicateUserException("이미 예약된 시간입니다. : ", dto.getDesiredDate() + "." + dto.getDesiredTime());
         }
     }
 }

--- a/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
@@ -8,7 +8,6 @@ import com.example.weesh.core.auth.application.token.TokenResolver;
 import com.example.weesh.core.auth.application.token.TokenValidator;
 import com.example.weesh.core.user.application.UserRepository;
 import com.example.weesh.core.user.domain.User;
-import com.example.weesh.core.user.exception.DuplicateUserException;
 import com.example.weesh.web.advice.dto.AdviceCreateRequestDto;
 import com.example.weesh.web.advice.dto.AdviceResponseDto;
 import com.example.weesh.web.advice.dto.AdviceUpdateRequestDro;
@@ -18,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
@@ -3,6 +3,7 @@ package com.example.weesh.core.advice.application;
 import com.example.weesh.core.advice.application.factory.AdviceFactory;
 import com.example.weesh.core.advice.application.useCase.*;
 import com.example.weesh.core.advice.domain.Advice;
+import com.example.weesh.core.advice.exception.DuplicateAdviceException;
 import com.example.weesh.core.auth.application.token.TokenResolver;
 import com.example.weesh.core.auth.application.token.TokenValidator;
 import com.example.weesh.core.user.application.UserRepository;
@@ -111,7 +112,7 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
 
     private void validateDuplicateAdvice(AdviceCreateRequestDto dto) {
         if (adviceRepository.existsByDateAndTime(dto.getDesiredDate(), dto.getDesiredTime())) {
-            throw new DuplicateUserException("이미 예약된 시간입니다. : ", dto.getDesiredDate() + "." + dto.getDesiredTime());
+            throw new DuplicateAdviceException("이미 예약된 시간입니다. : " + dto.getDesiredDate() + "." + dto.getDesiredTime());
         }
     }
 }

--- a/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
+++ b/src/main/java/com/example/weesh/core/advice/application/AdviceService.java
@@ -32,10 +32,11 @@ public class AdviceService implements AdviceCreateUseCase, AdviceReadUseCase, Ad
     public AdviceResponseDto createAdvice(AdviceCreateRequestDto dto, HttpServletRequest request) {
         String token = tokenResolver.resolveToken(request); // 요청에서 토큰 추출
         Long userId = token != null ? getUserIdFromToken(token) : null;
+        User user = userId != null ? userRepository.findById(userId) : null;
         validateAdviceRequest(dto, userId);
         validateDuplicateAdvice(dto);
         Advice advice = adviceFactory.createAdvice(dto, userId);
-        Advice savedAdvice = adviceRepository.save(advice);
+        Advice savedAdvice = adviceRepository.save(advice, user);
         return new AdviceResponseDto(savedAdvice);
     }
 

--- a/src/main/java/com/example/weesh/core/advice/exception/DuplicateAdviceException.java
+++ b/src/main/java/com/example/weesh/core/advice/exception/DuplicateAdviceException.java
@@ -1,0 +1,7 @@
+package com.example.weesh.core.advice.exception;
+
+public class DuplicateAdviceException extends RuntimeException{
+    public DuplicateAdviceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/weesh/data/factory/AdviceFactoryImpl.java
+++ b/src/main/java/com/example/weesh/data/factory/AdviceFactoryImpl.java
@@ -1,12 +1,9 @@
 package com.example.weesh.data.factory;
 
-import com.example.weesh.core.advice.application.AdviceRepository;
 import com.example.weesh.core.advice.application.factory.AdviceFactory;
 import com.example.weesh.core.advice.domain.Advice;
 import com.example.weesh.core.foundation.enums.AdviceStatus;
-import com.example.weesh.core.user.exception.DuplicateUserException;
 import com.example.weesh.web.advice.dto.AdviceCreateRequestDto;
-import com.example.weesh.web.user.dto.UserRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,13 +12,8 @@ import java.time.LocalDateTime;
 @Component
 @RequiredArgsConstructor
 public class AdviceFactoryImpl implements AdviceFactory {
-    private final AdviceRepository adviceRepository;
-
     @Override
     public Advice createAdvice(AdviceCreateRequestDto dto, Long userId) {
-        if (adviceRepository.existsByDateAndTime(dto.getDesiredDate(), dto.getDesiredTime())) {
-            throw new DuplicateUserException("이미 예약된 시간입니다. : ", dto.getDesiredDate() + "." + dto.getDesiredTime());
-        }
         return Advice.builder()
                 .desiredDate(dto.getDesiredDate())
                 .desiredTime(dto.getDesiredTime())

--- a/src/main/java/com/example/weesh/data/jpa/advice/AdviceRepositoryImpl.java
+++ b/src/main/java/com/example/weesh/data/jpa/advice/AdviceRepositoryImpl.java
@@ -3,10 +3,10 @@ package com.example.weesh.data.jpa.advice;
 import com.example.weesh.core.advice.application.AdviceRepository;
 import com.example.weesh.core.advice.domain.Advice;
 import com.example.weesh.core.foundation.enums.AdviceStatus;
+import com.example.weesh.core.user.domain.User;
 import com.example.weesh.data.jpa.advice.mapper.AdviceMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,10 +18,15 @@ public class AdviceRepositoryImpl implements AdviceRepository {
     private final AdviceMapper adviceMapper;
 
     @Override
-    public Advice save(Advice advice) {
-        AdviceEntity entity = adviceMapper.toEntity(advice);
+    public Advice save(Advice advice, User user) {
+        AdviceEntity entity = adviceMapper.toEntity(advice, user);
         AdviceEntity savedEntity = jpaRepository.save(entity);
         return adviceMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Advice save(Advice advice) {
+        return save(advice, null);
     }
 
     @Override

--- a/src/main/java/com/example/weesh/data/jpa/advice/mapper/AdviceMapper.java
+++ b/src/main/java/com/example/weesh/data/jpa/advice/mapper/AdviceMapper.java
@@ -2,7 +2,6 @@ package com.example.weesh.data.jpa.advice.mapper;
 
 import com.example.weesh.core.advice.domain.Advice;
 import com.example.weesh.core.foundation.enums.AdviceStatus;
-import com.example.weesh.core.user.application.UserRepository;
 import com.example.weesh.core.user.domain.User;
 import com.example.weesh.data.jpa.advice.AdviceEntity;
 import com.example.weesh.data.jpa.user.UserEntity;
@@ -15,7 +14,6 @@ import java.time.LocalDateTime;
 @Component
 @RequiredArgsConstructor
 public class AdviceMapper {
-    private final UserRepository userRepository;
     private final UserMapper userMapper;
 
     public Advice toDomain(AdviceEntity entity) {
@@ -34,15 +32,14 @@ public class AdviceMapper {
                 .build();
     }
 
-    public AdviceEntity toEntity(Advice advice) {
+    public AdviceEntity toEntity(Advice advice, User user) {
         if (advice == null) return null;
         AdviceEntity entity = new AdviceEntity();
         entity.setId(advice.getId());
         entity.setDesiredDate(advice.getDesiredDate());
         entity.setDesiredTime(advice.getDesiredTime());
         entity.setContent(advice.getContent());
-        if (advice.getUserId() != null) {
-            User user = userRepository.findById(advice.getUserId());
+        if (user != null) {
             UserEntity userEntity = userMapper.toEntity(user);
             entity.setUser(userEntity);
         }


### PR DESCRIPTION
- AdviceFactory에서 Repository 의존성 제거 → 조회/검증 책임을 Service로 이동
- AdviceMapper에서 UserRepository 의존성 제거 → 순수 매퍼로 변경
- toEntity 시그니처를 (Advice, User) 형태로 변경하여 User를 외부에서 주입
- 도메인 계층이 인프라 계층에 의존하지 않도록 구조 개선
- 기능 변경 없음